### PR TITLE
fix: Typo

### DIFF
--- a/src/contexts/LiveAPIContext.tsx
+++ b/src/contexts/LiveAPIContext.tsx
@@ -41,7 +41,7 @@ export const LiveAPIProvider: FC<LiveAPIProviderProps> = ({
 export const useLiveAPIContext = () => {
   const context = useContext(LiveAPIContext);
   if (!context) {
-    throw new Error("useLiveAPIContext must be used wihin a LiveAPIProvider");
+    throw new Error("useLiveAPIContext must be used within a LiveAPIProvider");
   }
   return context;
 };


### PR DESCRIPTION
With this PR, I've just fixed a small typo: `wihin` => `within`